### PR TITLE
尝试调试cygwin的诡异问题

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,13 +14,43 @@ backup_dotfile(){
     [ -f ~/.$1 ] && cp ~/.$1 ~/.backup/dotfiles/$1.bk.$ts
 }
 
+is_cygwin(){
+  uname -a | grep CYGWIN
+}
+
+is_linux(){
+  uname -a | grep Linux
+}
+
+install_vundle_in_cygwin(){
+
+  mkdir -p ~/.vim/bundle
+  
+  cd ~/.vim/bundle
+
+  git clone https://github.com/VundleVim/Vundle.vim.git
+
+  cd -
+}
+
+install_vim_vundle(){
+  is_cygwin && install_vundle_in_cygwin || git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
+}
+
 [[ $osname == "Linux" ]] && uname -a
 
 #curl -L https://raw.githubusercontent.com/juven/maven-bash-completion/master/bash_completion.bash -o ~/.maven_bash_completion.bash
 #curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker -o ~/.docker-completion.sh
 #curl -L https://raw.githubusercontent.com/git/git/v1.8.3.1/contrib/completion/git-completion.bash -o ~/.git-completion.bash
 
-[ -d ~/.vim/bundle/Vundle.vim ] && echo need not to clone vundle || git clone https://github.com/VundleVim/Vundle.vim.git ~/.vim/bundle/Vundle.vim
+mkdir -p ~/bin
+mkdir -p ~/opt
+mkdir -p ~/workspace
+mkdir -p ~/tmp
+
+[ -d ~/.vim/bundle/Vundle.vim ] && echo need not to clone vundle || install_vim_vundle
+
+pwd
 
 refresh_dotfile vimrc
 refresh_dotfile gitignore
@@ -28,7 +58,7 @@ refresh_dotfile screenrc
 # refresh_dotfile dir_colors
 
 git config --global color.ui true
-# git config --global core.autocrlf false
+git config --global core.autocrlf false
 # git config --global core.safecrlf warn
 git config --global core.excludesfile ~/.gitignore
 # git config --global push.default current
@@ -42,11 +72,6 @@ fi
 backup_dotfile bashrc
 grep "bashrc.my.sh" ~/.bashrc || printf "\nsource ~/dotfiles/files/bashrc.my.sh\n" >> ~/.bashrc
 grep "my-oh-bash.sh" ~/.bashrc || printf "\nbash ~/dotfiles/files/my-oh-bash.sh\n" >> ~/.bashrc
-
-mkdir -p ~/bin
-mkdir -p ~/opt
-mkdir -p ~/workspace
-mkdir -p ~/tmp
 
 # omz custom
 ln -sf ~/dotfiles/files/my-oh-zsh.zsh ~/.oh-my-zsh/custom/my-oh-zsh.zsh


### PR DESCRIPTION
+ 其实最后发现
  - 可能是使用独立的git-windows造成的
  - 使用cygwin安装git可能没事
+ 关于ssh agent以及screen中兼容的问题
  - 其实也是GIT_SSH配plink的问题
  - 当前的cygwin版本(3.x以上？)
    - 可以沿用git-windows安装包中win风格路径配置
  - 所以没有特殊处理
    - 没有特别适配针对linux发行版/var/run中路径期待
    - 以上报错直接无视即可，不会有副作用
+ 基于以上，暂时保留所有更改了，而不再继续尝试了
  - WSL2初始化验证过一遍
    - 除了WSL2自身特点的适配例如SSH_AUTH_SOCK问题
  - 后面再有问题再调整
  - 这么复杂这回不写蹩脚鸟文了，用天朝文！！！