### PR TITLE
增加一套初始的git配置

### DIFF
--- a/git/.config/git/.gitignore
+++ b/git/.config/git/.gitignore
@@ -1,0 +1,7 @@
+*.swp
+.project
+.settings
+.classpath
+.springBeans
+target
+logs/

--- a/git/.config/git/allowed_signers
+++ b/git/.config/git/allowed_signers
@@ -1,0 +1,1 @@
+leizhnxp@gmail.com,leizhenhua@arrailgroup.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHbWEZygV6f+MENAwwP24NwGGMOqKC0XkH6DjEE7PVSA zhenhua.lei@GUI

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,0 +1,13 @@
+[color]
+	ui = true
+[core]
+	autocrlf = false
+	excludesfile = ~/.config/git/.gitignore
+	attributesFile = ~/.config/git/.gitattributes
+	pager = less -F
+[gpg "ssh"]
+	allowedSignersFile = ~/.config/git/allowed_signers
+[gpg]
+	format = ssh
+[user]
+	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHbWEZygV6f+MENAwwP24NwGGMOqKC0XkH6DjEE7PVSA


### PR DESCRIPTION
切实有：
+ gitconfig
  - 入口
+ ignore
  - 全局忽略，目前只有java工程，看这个样子还是eclipse的
+ signers
  - git 用ssh签名相关的配置

占位的：
+ .gitattributes，原则上最好也是repo级，放这里也有个想法当备份了